### PR TITLE
Fix broken link of my GSoC 2016 proposal.

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
                             <li>
                                 Karan Desai - TARDIS
                                 <a target="_blank" href="https://summerofcode.withgoogle.com/archive/2016/projects/4796129849901056/">[Project]</a>
-                                <a target="_blank" href="http://opensupernova.org/gsoc2016/lib/exe/fetch.php?media=karandesai_gsoc_2016.pdf">[Proposal]</a>
+                                <a target="_blank" href="http://opensupernova.org/~wkerzend/gsoc2016/lib/exe/fetch.php?media=karandesai_gsoc_2016.pdf">[Proposal]</a>
                             </li>
                             <li>
                                 Ashish Chaudhary - CloudCV


### PR DESCRIPTION
My mentor changed the URL of the pdf hosted on TARDIS website. I just realized that students need to refer proposals as it is that time of the year again.